### PR TITLE
fix(a2a): validate remote agent URL before discovery

### DIFF
--- a/service/agent-service-app/src/main/java/com/openjiuwen/service/app/controller/a2a/client/A2AAgentCardDiscovery.java
+++ b/service/agent-service-app/src/main/java/com/openjiuwen/service/app/controller/a2a/client/A2AAgentCardDiscovery.java
@@ -62,7 +62,7 @@ public class A2AAgentCardDiscovery {
             Thread t = new Thread(r, "a2a-discovery-retry");
             t.setDaemon(true);
             t.setUncaughtExceptionHandler(
-                (thread, ex) -> log.error("Uncaught exception in discovery thread {}", thread.getName(), ex));
+                    (thread, ex) -> log.error("Uncaught exception in discovery thread {}", thread.getName(), ex));
             return t;
         });
     }
@@ -75,9 +75,21 @@ public class A2AAgentCardDiscovery {
         if (properties.getRemoteAgents().isEmpty()) {
             return;
         }
+        validateRemoteAgents();
         log.info("Discovering {} remote A2A agent(s)", properties.getRemoteAgents().size());
         for (var remote : properties.getRemoteAgents()) {
             tryDiscover(remote);
+        }
+    }
+
+    private void validateRemoteAgents() {
+        for (int index = 0; index < properties.getRemoteAgents().size(); index++) {
+            RemoteAgentProperties remote = properties.getRemoteAgents().get(index);
+            if (remote.getUrl() == null || remote.getUrl().isBlank()) {
+                throw new IllegalStateException("Remote agent '" + remote.getName()
+                        + "' has no URL configured. Set openjiuwen.service.a2a.remote-agents[" + index
+                        + "].url or remove this agent.");
+            }
         }
     }
 
@@ -86,7 +98,7 @@ public class A2AAgentCardDiscovery {
             discoverAndRegister(remote);
         } catch (org.springframework.web.client.RestClientException e) {
             log.warn("Failed to discover {}, retry every {}s: {}", remote.getName(), RETRY_INTERVAL_SECONDS,
-                e.getMessage());
+                    e.getMessage());
             ScheduledFuture<?> future = retryExecutor.scheduleWithFixedDelay(() -> {
                 try {
                     discoverAndRegister(remote);
@@ -94,7 +106,7 @@ public class A2AAgentCardDiscovery {
                     cancelRetry(remote.getName());
                 } catch (org.springframework.web.client.RestClientException ex) {
                     log.warn("Retry {} failed, will retry in {}s: {}", remote.getName(), RETRY_INTERVAL_SECONDS,
-                        ex.getMessage());
+                            ex.getMessage());
                 }
             }, RETRY_INTERVAL_SECONDS, RETRY_INTERVAL_SECONDS, TimeUnit.SECONDS);
             retryFutures.put(remote.getName(), future);
@@ -115,6 +127,9 @@ public class A2AAgentCardDiscovery {
     }
 
     AgentCard fetchCard(String baseUrl) {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            throw new IllegalArgumentException("baseUrl must not be null or blank");
+        }
         String cardUrl = baseUrl.replaceAll("/$", "") + "/.well-known/agent-card.json";
         return restClient.get().uri(cardUrl).accept(MediaType.APPLICATION_JSON).retrieve().body(AgentCard.class);
     }

--- a/service/agent-service-app/src/test/java/com/openjiuwen/service/app/controller/a2a/client/A2AAgentCardDiscoveryTest.java
+++ b/service/agent-service-app/src/test/java/com/openjiuwen/service/app/controller/a2a/client/A2AAgentCardDiscoveryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.service.app.controller.a2a.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.openjiuwen.service.app.config.A2AProperties;
+import com.openjiuwen.service.app.config.A2AProperties.RemoteAgentProperties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link A2AAgentCardDiscovery} configuration validation.
+ *
+ * @since 0.1.0
+ */
+class A2AAgentCardDiscoveryTest {
+    private A2AAgentCardDiscovery discovery;
+
+    @AfterEach
+    void tearDown() {
+        if (discovery != null) {
+            discovery.shutdown();
+        }
+    }
+
+    @Test
+    void missingRemoteAgentUrlFailsWithConfigurationKey() {
+        A2AProperties properties = propertiesWith(remoteAgent("weather-agent", null));
+        discovery = new A2AAgentCardDiscovery(properties, new A2ARemoteAgentCardRegistry());
+
+        assertThatThrownBy(discovery::discoverAll).isInstanceOf(IllegalStateException.class)
+                .hasMessage("Remote agent 'weather-agent' has no URL configured. "
+                        + "Set openjiuwen.service.a2a.remote-agents[0].url or remove this agent.");
+    }
+
+    @Test
+    void allRemoteAgentsAreValidatedBeforeDiscoveryStarts() {
+        A2AProperties properties = propertiesWith(remoteAgent("weather-agent", "not a URI"),
+                remoteAgent("travel-agent", "   "));
+        discovery = new A2AAgentCardDiscovery(properties, new A2ARemoteAgentCardRegistry());
+
+        assertThatThrownBy(discovery::discoverAll).isInstanceOf(IllegalStateException.class)
+                .hasMessage("Remote agent 'travel-agent' has no URL configured. "
+                        + "Set openjiuwen.service.a2a.remote-agents[1].url or remove this agent.");
+    }
+
+    @Test
+    void fetchCardRejectsMissingBaseUrl() {
+        discovery = new A2AAgentCardDiscovery(new A2AProperties(), new A2ARemoteAgentCardRegistry());
+
+        assertThatThrownBy(() -> discovery.fetchCard(null)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("baseUrl must not be null or blank");
+    }
+
+    private static A2AProperties propertiesWith(RemoteAgentProperties... remoteAgents) {
+        A2AProperties properties = new A2AProperties();
+        properties.setRemoteAgents(List.of(remoteAgents));
+        return properties;
+    }
+
+    private static RemoteAgentProperties remoteAgent(String name, String url) {
+        RemoteAgentProperties remote = new RemoteAgentProperties();
+        remote.setName(name);
+        remote.setUrl(url);
+        return remote;
+    }
+}


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

**What type of PR is this?**

/kind bug

## 变更说明

- 在 A2A 远程 Agent 发现开始前校验全部 `remote-agents[].url`，避免部分初始化。
- URL 缺失或仅包含空白时抛出带精确配置键的 `IllegalStateException`，替代原来的 `NullPointerException`。
- 在 `fetchCard()` 保留底层参数防御，并新增缺失 URL、空白 URL 和校验顺序的回归测试。

## 验证

- `mvn -pl service/agent-service-app -am -Dtest=A2AAgentCardDiscoveryTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 3 tests，0 failures/errors/skips
- `mvn -pl service/agent-service-app -am test`
  - agent-service-spec: 12 tests
  - agent-service-adapters-common: 46 tests
  - agent-service-app: 192 tests
  - 全部通过
- `service/agent-service-demo/example/a2a/smoke-a2a.sh`
  - Agent A/B/C 健康检查通过
  - Agent Card 检查通过
  - A -> B 计算确认与恢复通过
  - A -> B -> C 到达 Agent C 确认中断

Fixes #43

**Self-checklist**:

+ - [x] **设计**：采用 issue #43 推荐的启动时校验方案，并在底层保留参数防御；不引入 URL 推断或宽泛异常捕获。
+ - [x] **测试**：新增 3 个回归测试，完整模块测试共 250 个测试全部通过。
+ - [x] **验证**：已运行真实 LLM 与本地 Redis 的 A2A 端到端 smoke，验证结果见上文。
+ - [x] **接口**：不变更公共 Java API；仅将缺失 URL 的 NPE 改为包含配置键的明确异常。
+ - [x] **文档**：不新增或变更配置项，无需修改官网文档。