### PR TITLE
fix(a2a): validate remote agent name before discovery

### DIFF
--- a/service/agent-service-app/src/main/java/com/openjiuwen/service/app/controller/a2a/client/A2AAgentCardDiscovery.java
+++ b/service/agent-service-app/src/main/java/com/openjiuwen/service/app/controller/a2a/client/A2AAgentCardDiscovery.java
@@ -34,6 +34,8 @@ import java.util.concurrent.TimeUnit;
 public class A2AAgentCardDiscovery {
     private static final Logger log = LoggerFactory.getLogger(A2AAgentCardDiscovery.class);
 
+    private static final String REMOTE_AGENTS_PROPERTY = "openjiuwen.service.a2a.remote-agents";
+
     private static final long RETRY_INTERVAL_SECONDS = 30L;
 
     private static final long SHUTDOWN_TIMEOUT_SECONDS = 5L;
@@ -85,11 +87,16 @@ public class A2AAgentCardDiscovery {
     private void validateRemoteAgents() {
         for (int index = 0; index < properties.getRemoteAgents().size(); index++) {
             RemoteAgentProperties remote = properties.getRemoteAgents().get(index);
-            if (remote.getUrl() == null || remote.getUrl().isBlank()) {
-                throw new IllegalStateException("Remote agent '" + remote.getName()
-                        + "' has no URL configured. Set openjiuwen.service.a2a.remote-agents[" + index
-                        + "].url or remove this agent.");
-            }
+            String propertyPrefix = REMOTE_AGENTS_PROPERTY + "[" + index + "]";
+            validateRequiredProperty(remote.getName(), propertyPrefix + ".name");
+            validateRequiredProperty(remote.getUrl(), propertyPrefix + ".url");
+        }
+    }
+
+    private static void validateRequiredProperty(String value, String propertyPath) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(
+                    "Invalid A2A remote agent configuration: " + propertyPath + " must not be null or blank");
         }
     }
 

--- a/service/agent-service-app/src/test/java/com/openjiuwen/service/app/controller/a2a/client/A2AAgentCardDiscoveryTest.java
+++ b/service/agent-service-app/src/test/java/com/openjiuwen/service/app/controller/a2a/client/A2AAgentCardDiscoveryTest.java
@@ -11,6 +11,9 @@ import com.openjiuwen.service.app.config.A2AProperties.RemoteAgentProperties;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 
@@ -35,8 +38,30 @@ class A2AAgentCardDiscoveryTest {
         discovery = new A2AAgentCardDiscovery(properties, new A2ARemoteAgentCardRegistry());
 
         assertThatThrownBy(discovery::discoverAll).isInstanceOf(IllegalStateException.class)
-                .hasMessage("Remote agent 'weather-agent' has no URL configured. "
-                        + "Set openjiuwen.service.a2a.remote-agents[0].url or remove this agent.");
+                .hasMessage("Invalid A2A remote agent configuration: "
+                        + "openjiuwen.service.a2a.remote-agents[0].url must not be null or blank");
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", "   "})
+    void missingRemoteAgentNameFailsWithConfigurationKey(String name) {
+        A2AProperties properties = propertiesWith(remoteAgent(name, "http://127.0.0.1:12345"));
+        discovery = new A2AAgentCardDiscovery(properties, new A2ARemoteAgentCardRegistry());
+
+        assertThatThrownBy(discovery::discoverAll).isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invalid A2A remote agent configuration: "
+                        + "openjiuwen.service.a2a.remote-agents[0].name must not be null or blank");
+    }
+
+    @Test
+    void missingNameIsReportedBeforeMissingUrl() {
+        A2AProperties properties = propertiesWith(remoteAgent(null, null));
+        discovery = new A2AAgentCardDiscovery(properties, new A2ARemoteAgentCardRegistry());
+
+        assertThatThrownBy(discovery::discoverAll).isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invalid A2A remote agent configuration: "
+                        + "openjiuwen.service.a2a.remote-agents[0].name must not be null or blank");
     }
 
     @Test
@@ -46,8 +71,8 @@ class A2AAgentCardDiscoveryTest {
         discovery = new A2AAgentCardDiscovery(properties, new A2ARemoteAgentCardRegistry());
 
         assertThatThrownBy(discovery::discoverAll).isInstanceOf(IllegalStateException.class)
-                .hasMessage("Remote agent 'travel-agent' has no URL configured. "
-                        + "Set openjiuwen.service.a2a.remote-agents[1].url or remove this agent.");
+                .hasMessage("Invalid A2A remote agent configuration: "
+                        + "openjiuwen.service.a2a.remote-agents[1].url must not be null or blank");
     }
 
     @Test


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

**What type of PR is this?**

/kind bug

## 背景与根因

这是 #43 和已合并 PR !99 的后续修复。!99 只校验了远程 Agent 的 `url`，遗漏了同样必填的 `name`。

当 `name=null` 且 Agent Card 请求失败时，发现逻辑会创建重试任务，随后执行 `retryFutures.put(null, future)`；`ConcurrentHashMap` 不允许 null key，因此再次抛出 `NullPointerException`。如果请求成功，注册表执行 `entries.put(null, ...)` 时也会出现同类 NPE。空字符串或纯空白名称则会产生无效注册键和重试键。

## 变更说明

- 将远程 Agent 的 `name` 和 `url` 统一定义为非 null、非空白的必填配置。
- 在任何网络请求、重试任务或注册操作之前预校验完整远程 Agent 列表。
- 固定先校验 `name`、再校验 `url`；两者同时缺失时优先报告 `.name`。
- 统一错误类型和属性路径格式，例如：

```text
Invalid A2A remote agent configuration: openjiuwen.service.a2a.remote-agents[0].name must not be null or blank
```

- 补充 `name=null`、空字符串、纯空白、name/url 同时缺失及全列表预校验的回归覆盖。

## 行为边界

- 保持严格 fail-fast 语义：显式配置的远程 Agent 缺少 `name` 或 `url` 时，应用以明确的 `IllegalStateException` 终止启动。
- 不引入非法 Agent 跳过、URL 自动推断或服务发现。
- 合法远程 Agent 的发现与网络失败重试行为不变。

## 验证

- 定向测试：
  - `mvn -pl service/agent-service-app -am -Dtest=A2AAgentCardDiscoveryTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 7 tests，0 failures/errors/skips
- 完整模块测试：
  - `mvn -pl service/agent-service-app -am test`
  - agent-service-spec: 12 tests
  - agent-service-adapters-common: 46 tests
  - agent-service-app: 200 tests
  - 共 258 tests，全部通过
- 真实 A2A 端到端：
  - Agent A/B/C 健康检查和 Agent Card 通过
  - A -> B 计算确认与恢复通过
  - A -> B -> C 确认中断、第二轮恢复和最终推荐通过
- pre-commit Eclipse JDT、Checkstyle 和远端 Git Hooks 全部通过。

Fixes #43

**Self-checklist**:

+ - [x] **设计**：已确认 `name`/`url` 都采用严格 fail-fast 必填配置语义。
+ - [x] **测试**：新增 name null/blank 和字段优先级回归测试，并完成模块全量测试。
+ - [x] **验证**：完成真实 LLM 与本地 Redis 的完整 A2A 端到端。
+ - [x] **接口**：不变更公共 Java API，只统一配置校验行为和错误信息。
+ - [x] **文档**：不新增配置项，无需修改官网文档。