### PR TITLE
fix(redis): improve endpoint and cluster reliability

### DIFF
--- a/service/agent-service-adapters/agent-service-adapters-agentcore/src/main/java/com/openjiuwen/service/adapters/agentcore/middleware/AgentCoreCheckpointerConfigAssembler.java
+++ b/service/agent-service-adapters/agent-service-adapters-agentcore/src/main/java/com/openjiuwen/service/adapters/agentcore/middleware/AgentCoreCheckpointerConfigAssembler.java
@@ -8,6 +8,7 @@ import com.openjiuwen.service.adapters.common.credential.CredentialDecryptor;
 import com.openjiuwen.service.adapters.common.credential.CredentialSceneType;
 import com.openjiuwen.service.adapters.common.middleware.MiddlewareProperties;
 import com.openjiuwen.service.adapters.common.middleware.redis.RedisConnectionAssembler;
+import com.openjiuwen.service.adapters.common.middleware.redis.ResolvedRedisEndpoint;
 import com.openjiuwen.service.spec.spi.RuntimeRedisClient;
 
 import java.util.HashMap;
@@ -63,7 +64,7 @@ public final class AgentCoreCheckpointerConfigAssembler {
             throw new IllegalStateException("RuntimeRedisClient is required for redis checkpointer");
         }
         String redisRef = properties.getCheckpointer().getRedisRef();
-        MiddlewareProperties.RedisEndpoint endpoint = RedisConnectionAssembler.resolveEndpoint(properties, redisRef);
+        ResolvedRedisEndpoint endpoint = RedisConnectionAssembler.resolve(properties, redisRef);
         String password = decryptor.decrypt(endpoint.getEncryptedPassword(), CredentialSceneType.REDIS_PASSWORD);
 
         Map<String, Object> connection = new HashMap<>(RedisConnectionAssembler.buildConnectionMap(endpoint, password));

--- a/service/agent-service-adapters/agent-service-adapters-agentcore/src/test/java/com/openjiuwen/service/adapters/agentcore/agentfw/RedisCheckpointerMiddlewareIT.java
+++ b/service/agent-service-adapters/agent-service-adapters-agentcore/src/test/java/com/openjiuwen/service/adapters/agentcore/agentfw/RedisCheckpointerMiddlewareIT.java
@@ -16,6 +16,7 @@ import com.openjiuwen.service.adapters.common.credential.CredentialSceneType;
 import com.openjiuwen.service.adapters.common.credential.PassthroughCredentialDecryptor;
 import com.openjiuwen.service.adapters.common.middleware.MiddlewareProperties;
 import com.openjiuwen.service.adapters.common.middleware.redis.JedisPooledRuntimeRedisClient;
+import com.openjiuwen.service.adapters.common.middleware.redis.RedisConnectionAssembler;
 import com.openjiuwen.service.adapters.common.middleware.redis.RedisJedisClientFactory;
 import com.openjiuwen.service.spec.dto.QueryResponse;
 import com.openjiuwen.service.spec.dto.ServeRequest;
@@ -204,7 +205,7 @@ class RedisCheckpointerMiddlewareIT {
 
     private static RuntimeRedisClient runtimeRedisClient(MiddlewareProperties properties,
             CredentialDecryptor decryptor) {
-        MiddlewareProperties.RedisEndpoint endpoint = properties.getRedis().get("default");
+        var endpoint = RedisConnectionAssembler.resolve(properties, "default");
         String password = decryptor.decrypt(endpoint.getEncryptedPassword(), CredentialSceneType.REDIS_PASSWORD);
         return new JedisPooledRuntimeRedisClient(RedisJedisClientFactory.createPooled(endpoint, password));
     }

--- a/service/agent-service-adapters/agent-service-adapters-agentcore/src/test/java/com/openjiuwen/service/adapters/agentcore/middleware/AgentCoreCheckpointerConfigAssemblerTest.java
+++ b/service/agent-service-adapters/agent-service-adapters-agentcore/src/test/java/com/openjiuwen/service/adapters/agentcore/middleware/AgentCoreCheckpointerConfigAssemblerTest.java
@@ -57,7 +57,9 @@ class AgentCoreCheckpointerConfigAssemblerTest {
         MiddlewareProperties properties = new MiddlewareProperties();
         properties.getCheckpointer().setType("redis");
         properties.getCheckpointer().setTtlSeconds(30L);
-        properties.getRedis().put("default", new MiddlewareProperties.RedisEndpoint());
+        MiddlewareProperties.RedisEndpoint endpoint = new MiddlewareProperties.RedisEndpoint();
+        endpoint.setHost("127.0.0.1");
+        properties.getRedis().put("default", endpoint);
 
         Map<String, Object> config = AgentCoreCheckpointerConfigAssembler.build(properties, value -> value,
                 new NoopRuntimeRedisClient());

--- a/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/MiddlewareProperties.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/MiddlewareProperties.java
@@ -141,7 +141,7 @@ public class MiddlewareProperties {
     public static class RedisEndpoint {
         private String type = "standalone";
 
-        private String host = "localhost";
+        private String host;
 
         private int port = 6379;
 

--- a/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/JedisClusterRuntimeRedisClient.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/JedisClusterRuntimeRedisClient.java
@@ -9,11 +9,17 @@ import com.openjiuwen.service.spec.spi.RuntimeRedisClient;
 import redis.clients.jedis.ConnectionPool;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.util.JedisClusterCRC16;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -24,19 +30,82 @@ import java.util.Set;
 public class JedisClusterRuntimeRedisClient extends UnifiedJedisRuntimeRedisClient {
     private final JedisCluster cluster;
 
+    private final UnifiedJedis commandDelegate;
+
     /**
      * Creates a runtime Redis cluster client.
      *
      * @param delegate Jedis cluster client
      */
     public JedisClusterRuntimeRedisClient(JedisCluster delegate) {
+        this(delegate, delegate);
+    }
+
+    JedisClusterRuntimeRedisClient(UnifiedJedis delegate) {
+        this(delegate, null);
+    }
+
+    private JedisClusterRuntimeRedisClient(UnifiedJedis delegate, JedisCluster cluster) {
         super(delegate);
-        this.cluster = delegate;
+        this.commandDelegate = delegate;
+        this.cluster = cluster;
+    }
+
+    @Override
+    public List<Object> mget(String... keys) {
+        Map<Integer, List<IndexedBinaryKey>> groups = new LinkedHashMap<>();
+        for (int index = 0; index < keys.length; index++) {
+            byte[] key = toBytes(keys[index]);
+            groups.computeIfAbsent(JedisClusterCRC16.getSlot(key), ignored -> new ArrayList<>())
+                    .add(new IndexedBinaryKey(index, key));
+        }
+        List<Object> orderedValues = new ArrayList<>(Collections.nCopies(keys.length, null));
+        int completedGroups = 0;
+        for (Map.Entry<Integer, List<IndexedBinaryKey>> group : groups.entrySet()) {
+            List<IndexedBinaryKey> indexedKeys = group.getValue();
+            byte[][] slotKeys = indexedKeys.stream().map(IndexedBinaryKey::key).toArray(byte[][]::new);
+            List<byte[]> slotValues;
+            try {
+                slotValues = commandDelegate.mget(slotKeys);
+            } catch (JedisException ex) {
+                throw multiKeyFailure("mget", group.getKey(), new OperationProgress(completedGroups, groups.size(), 0L),
+                        ex);
+            }
+            if (slotValues.size() != indexedKeys.size()) {
+                IllegalStateException cause = new IllegalStateException("Redis Cluster mget returned "
+                        + slotValues.size() + " values for " + indexedKeys.size() + " keys");
+                throw multiKeyFailure("mget", group.getKey(), new OperationProgress(completedGroups, groups.size(), 0L),
+                        cause);
+            }
+            for (int valueIndex = 0; valueIndex < slotValues.size(); valueIndex++) {
+                orderedValues.set(indexedKeys.get(valueIndex).index(), slotValues.get(valueIndex));
+            }
+            completedGroups++;
+        }
+        return orderedValues;
+    }
+
+    @Override
+    public long del(String... keys) {
+        Map<Integer, List<String>> groups = new LinkedHashMap<>();
+        for (String key : keys) {
+            groups.computeIfAbsent(JedisClusterCRC16.getSlot(key), ignored -> new ArrayList<>()).add(key);
+        }
+        return deleteTextGroups(groups);
+    }
+
+    @Override
+    public long del(byte[]... keys) {
+        Map<Integer, List<byte[]>> groups = new LinkedHashMap<>();
+        for (byte[] key : keys) {
+            groups.computeIfAbsent(JedisClusterCRC16.getSlot(key), ignored -> new ArrayList<>()).add(key);
+        }
+        return deleteBinaryGroups(groups);
     }
 
     @Override
     public List<String> scanIter(String pattern) {
-        if (cluster.getClusterNodes().isEmpty()) {
+        if (cluster == null || cluster.getClusterNodes().isEmpty()) {
             return super.scanIter(pattern);
         }
         Set<String> keys = new LinkedHashSet<>();
@@ -57,5 +126,58 @@ public class JedisClusterRuntimeRedisClient extends UnifiedJedisRuntimeRedisClie
                 cursor = result.getCursor();
             }
         } while (!ScanParams.SCAN_POINTER_START.equals(cursor));
+    }
+
+    private long deleteTextGroups(Map<Integer, List<String>> groups) {
+        long deleted = 0L;
+        int completedGroups = 0;
+        for (Map.Entry<Integer, List<String>> group : groups.entrySet()) {
+            try {
+                deleted += commandDelegate.del(group.getValue().toArray(String[]::new));
+                completedGroups++;
+            } catch (JedisException ex) {
+                throw multiKeyFailure("del", group.getKey(),
+                        new OperationProgress(completedGroups, groups.size(), deleted), ex);
+            }
+        }
+        return deleted;
+    }
+
+    private long deleteBinaryGroups(Map<Integer, List<byte[]>> groups) {
+        long deleted = 0L;
+        int completedGroups = 0;
+        for (Map.Entry<Integer, List<byte[]>> group : groups.entrySet()) {
+            try {
+                deleted += commandDelegate.del(group.getValue().toArray(byte[][]::new));
+                completedGroups++;
+            } catch (JedisException ex) {
+                throw multiKeyFailure("binary del", group.getKey(),
+                        new OperationProgress(completedGroups, groups.size(), deleted), ex);
+            }
+        }
+        return deleted;
+    }
+
+    private IllegalStateException multiKeyFailure(String operation, int slot, OperationProgress progress,
+            RuntimeException cause) {
+        String deletedSummary = operation.contains("del") ? ", deletedBeforeFailure=" + progress.deleted() : "";
+        return new IllegalStateException(
+                "Redis Cluster " + operation + " failed for slot=" + slot + ", completedGroups="
+                        + progress.completedGroups() + ", totalGroups=" + progress.totalGroups() + deletedSummary,
+                cause);
+    }
+
+    private record OperationProgress(int completedGroups, int totalGroups, long deleted) {
+    }
+
+    private record IndexedBinaryKey(int index, byte[] key) {
+        private IndexedBinaryKey {
+            key = Arrays.copyOf(key, key.length);
+        }
+
+        @Override
+        public byte[] key() {
+            return Arrays.copyOf(key, key.length);
+        }
     }
 }

--- a/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisConnectionAssembler.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisConnectionAssembler.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Engine-agnostic Redis connection description from middleware properties.
+ * Resolves middleware properties into validated, engine-agnostic Redis connection descriptions.
  *
  * @since 0.1.0
  */
@@ -27,33 +27,185 @@ public final class RedisConnectionAssembler {
     /** Redis Cluster endpoint type. */
     public static final String TYPE_CLUSTER = "cluster";
 
+    private static final int DEFAULT_PORT = 6379;
+
+    private static final int DEFAULT_TIMEOUT_MS = 3000;
+
     private RedisConnectionAssembler() {
     }
 
     /**
-     * Resolves a named Redis endpoint from middleware properties.
+     * Resolves and validates a named Redis endpoint from middleware properties.
      *
      * @param properties the middleware properties
      * @param redisRef the redis endpoint reference name
-     * @return the resolved Redis endpoint
+     * @return an immutable resolved endpoint
      */
-    public static MiddlewareProperties.RedisEndpoint resolveEndpoint(MiddlewareProperties properties, String redisRef) {
-        String ref = redisRef;
-        if (ref == null || ref.isBlank()) {
-            ref = "default";
-        }
+    public static ResolvedRedisEndpoint resolve(MiddlewareProperties properties, String redisRef) {
+        String ref = normalizedRef(redisRef);
         MiddlewareProperties.RedisEndpoint endpoint = properties.getRedis().get(ref);
         if (endpoint == null) {
             throw new IllegalArgumentException(
                     "openjiuwen.service.middleware.redis." + ref + " is required for redis middleware");
         }
-        return endpoint;
+        return resolveEndpoint(ref, endpoint);
+    }
+
+    /**
+     * Resolves and validates a named Redis endpoint while preserving the original raw-endpoint API.
+     *
+     * @param properties the middleware properties
+     * @param redisRef the redis endpoint reference name
+     * @return the raw endpoint after validation
+     */
+    public static MiddlewareProperties.RedisEndpoint resolveEndpoint(MiddlewareProperties properties, String redisRef) {
+        ResolvedRedisEndpoint resolved = resolve(properties, redisRef);
+        return properties.getRedis().get(resolved.getRef());
+    }
+
+    /**
+     * Resolves and validates a Redis endpoint using the supplied reference in validation messages.
+     *
+     * @param redisRef the redis endpoint reference name
+     * @param endpoint the raw endpoint properties
+     * @return an immutable resolved endpoint
+     */
+    public static ResolvedRedisEndpoint resolveEndpoint(String redisRef, MiddlewareProperties.RedisEndpoint endpoint) {
+        String ref = normalizedRef(redisRef);
+        String type = resolveEndpointType(endpoint);
+        int port = endpoint.getPort() > 0 ? endpoint.getPort() : DEFAULT_PORT;
+        int database = endpoint.getDatabase() >= 0 ? endpoint.getDatabase() : 0;
+        int timeoutMs = endpoint.getTimeoutMs() > 0 ? endpoint.getTimeoutMs() : DEFAULT_TIMEOUT_MS;
+        String encryptedPassword = endpoint.getEncryptedPassword() != null ? endpoint.getEncryptedPassword() : "";
+        if (TYPE_CLUSTER.equals(type)) {
+            return new ResolvedRedisEndpoint(ref, type, null, port, clusterNodes(ref, endpoint), database, timeoutMs,
+                    encryptedPassword);
+        }
+        String host = endpoint.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException(
+                    "openjiuwen.service.middleware.redis." + ref + ".host is required when type=standalone");
+        }
+        return new ResolvedRedisEndpoint(ref, type, host.trim(), port, List.of(), database, timeoutMs,
+                encryptedPassword);
+    }
+
+    /**
+     * Builds a non-sensitive endpoint summary for diagnostics.
+     *
+     * @param endpoint the resolved endpoint
+     * @return a safe summary that does not contain passwords or ciphertext
+     */
+    public static String safeSummary(ResolvedRedisEndpoint endpoint) {
+        boolean isPasswordConfigured = !endpoint.getEncryptedPassword().isBlank();
+        if (endpoint.isCluster()) {
+            StringBuilder summary = new StringBuilder().append("ref=").append(endpoint.getRef()).append(", type=")
+                    .append(endpoint.getType()).append(", nodes=").append(endpoint.getNodes().size())
+                    .append(", timeoutMs=").append(endpoint.getTimeoutMs()).append(", passwordConfigured=")
+                    .append(isPasswordConfigured);
+            if (endpoint.getDatabase() != 0) {
+                summary.append(", databaseIgnored=").append(endpoint.getDatabase());
+            }
+            return summary.toString();
+        }
+        return "ref=" + endpoint.getRef() + ", type=" + endpoint.getType() + ", host=" + endpoint.getHost() + ", port="
+                + endpoint.getPort() + ", database=" + endpoint.getDatabase() + ", timeoutMs=" + endpoint.getTimeoutMs()
+                + ", passwordConfigured=" + isPasswordConfigured;
+    }
+
+    /**
+     * Builds a safe summary through the centralized endpoint resolver.
+     *
+     * @param redisRef the endpoint reference
+     * @param endpoint the raw endpoint properties
+     * @return a non-sensitive endpoint summary
+     */
+    public static String safeSummary(String redisRef, MiddlewareProperties.RedisEndpoint endpoint) {
+        return safeSummary(resolveEndpoint(redisRef, endpoint));
+    }
+
+    /**
+     * Builds a connection map from a resolved Redis endpoint.
+     *
+     * @param endpoint the resolved endpoint
+     * @param decryptedPassword the decrypted password
+     * @return the connection map
+     */
+    public static Map<String, Object> buildConnectionMap(ResolvedRedisEndpoint endpoint, String decryptedPassword) {
+        Map<String, Object> connection = new LinkedHashMap<>();
+        connection.put("url", buildRedisUrl(endpoint, decryptedPassword));
+        return connection;
+    }
+
+    /**
+     * Builds a connection map through the centralized endpoint resolver.
+     *
+     * @param endpoint the raw endpoint properties
+     * @param decryptedPassword the decrypted password
+     * @return the connection map
+     */
+    public static Map<String, Object> buildConnectionMap(MiddlewareProperties.RedisEndpoint endpoint,
+            String decryptedPassword) {
+        return buildConnectionMap(resolveEndpoint("default", endpoint), decryptedPassword);
+    }
+
+    /**
+     * Builds a connection map from middleware properties and a Redis reference.
+     *
+     * @param properties the middleware properties
+     * @param redisRef the redis endpoint reference name
+     * @param decryptor the credential decryptor
+     * @return the connection map
+     */
+    public static Map<String, Object> buildConnectionMap(MiddlewareProperties properties, String redisRef,
+            CredentialDecryptor decryptor) {
+        ResolvedRedisEndpoint endpoint = resolve(properties, redisRef);
+        String password = decryptor.decrypt(endpoint.getEncryptedPassword(), CredentialSceneType.REDIS_PASSWORD);
+        return buildConnectionMap(endpoint, password);
+    }
+
+    /**
+     * Builds a Redis URL from resolved endpoint settings and password.
+     *
+     * <p>For a Cluster endpoint the first validated node is used only as the connection-map seed. Runtime commands
+     * continue to use the topology-aware {@code RuntimeRedisClient} supplied alongside this URL.
+     *
+     * @param endpoint the resolved endpoint
+     * @param password the decrypted password, may be blank
+     * @return the Redis URL string
+     */
+    public static String buildRedisUrl(ResolvedRedisEndpoint endpoint, String password) {
+        String host = endpoint.getHost();
+        int port = endpoint.getPort();
+        int database = endpoint.getDatabase();
+        if (endpoint.isCluster()) {
+            NodeAddress seed = parseNode(endpoint.getNodes().get(0));
+            host = seed.host();
+            port = seed.port();
+            database = 0;
+        }
+        if (password == null || password.isBlank()) {
+            return "redis://" + host + ":" + port + "/" + database;
+        }
+        String encodedPassword = URLEncoder.encode(password, StandardCharsets.UTF_8);
+        return "redis://:" + encodedPassword + "@" + host + ":" + port + "/" + database;
+    }
+
+    /**
+     * Builds a Redis URL through the centralized endpoint resolver.
+     *
+     * @param endpoint the raw endpoint properties
+     * @param password the decrypted password, may be blank
+     * @return the Redis URL string
+     */
+    public static String buildRedisUrl(MiddlewareProperties.RedisEndpoint endpoint, String password) {
+        return buildRedisUrl(resolveEndpoint("default", endpoint), password);
     }
 
     /**
      * Resolves and validates the endpoint type.
      *
-     * @param endpoint the Redis endpoint
+     * @param endpoint the raw endpoint properties
      * @return normalized endpoint type
      */
     public static String resolveEndpointType(MiddlewareProperties.RedisEndpoint endpoint) {
@@ -72,131 +224,55 @@ public final class RedisConnectionAssembler {
     /**
      * Returns validated Redis Cluster seed nodes.
      *
-     * @param endpoint the Redis endpoint
-     * @return cluster seed node strings
+     * @param endpoint the raw endpoint properties
+     * @return normalized seed node strings
      */
     public static List<String> clusterNodes(MiddlewareProperties.RedisEndpoint endpoint) {
+        return clusterNodes("<ref>", endpoint);
+    }
+
+    private static List<String> clusterNodes(String ref, MiddlewareProperties.RedisEndpoint endpoint) {
         List<String> nodes = new ArrayList<>();
         for (String rawNode : endpoint.getNodes()) {
             if (rawNode == null || rawNode.isBlank()) {
                 continue;
             }
             String node = rawNode.trim();
-            validateClusterNode(node);
+            validateClusterNode(ref, node);
             nodes.add(node);
         }
         if (nodes.isEmpty()) {
             throw new IllegalArgumentException(
-                    "openjiuwen.service.middleware.redis.<ref>.nodes is required for cluster redis middleware");
+                    "openjiuwen.service.middleware.redis." + ref + ".nodes is required when type=cluster");
         }
         return nodes;
     }
 
-    /**
-     * Builds a non-sensitive endpoint summary for diagnostics.
-     *
-     * @param redisRef the redis endpoint reference name
-     * @param endpoint the Redis endpoint
-     * @return a safe summary that does not contain passwords or ciphertext
-     */
-    public static String safeSummary(String redisRef, MiddlewareProperties.RedisEndpoint endpoint) {
-        String ref = redisRef == null || redisRef.isBlank() ? "default" : redisRef.trim();
-        String type = resolveEndpointType(endpoint);
-        boolean isPasswordConfigured = endpoint.getEncryptedPassword() != null
-                && !endpoint.getEncryptedPassword().isBlank();
-        if (TYPE_CLUSTER.equals(type)) {
-            StringBuilder summary = new StringBuilder().append("ref=").append(ref).append(", type=").append(type)
-                    .append(", nodes=").append(clusterNodes(endpoint).size()).append(", timeoutMs=")
-                    .append(timeoutMs(endpoint)).append(", passwordConfigured=").append(isPasswordConfigured);
-            if (endpoint.getDatabase() != 0) {
-                summary.append(", databaseIgnored=").append(endpoint.getDatabase());
+    private static void validateClusterNode(String ref, String node) {
+        try {
+            NodeAddress address = parseNode(node);
+            if (address.host().isBlank() || address.port() <= 0) {
+                throw new IllegalArgumentException();
             }
-            return summary.toString();
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException(
+                    "openjiuwen.service.middleware.redis." + ref + ".nodes entries must use host:port format: " + node,
+                    ex);
         }
-        return "ref=" + ref + ", type=" + type + ", host=" + host(endpoint) + ", port=" + port(endpoint) + ", database="
-                + database(endpoint) + ", timeoutMs=" + timeoutMs(endpoint) + ", passwordConfigured="
-                + isPasswordConfigured;
     }
 
-    /**
-     * Builds a connection map from a resolved Redis endpoint.
-     *
-     * @param endpoint the Redis endpoint
-     * @param decryptedPassword the decrypted password
-     * @return the connection map
-     */
-    public static Map<String, Object> buildConnectionMap(MiddlewareProperties.RedisEndpoint endpoint,
-            String decryptedPassword) {
-        Map<String, Object> connection = new LinkedHashMap<>();
-        connection.put("url", buildRedisUrl(endpoint, decryptedPassword));
-        return connection;
-    }
-
-    /**
-     * Builds a connection map from middleware properties and a Redis reference.
-     *
-     * @param properties the middleware properties
-     * @param redisRef the redis endpoint reference name
-     * @param decryptor the credential decryptor
-     * @return the connection map
-     */
-    public static Map<String, Object> buildConnectionMap(MiddlewareProperties properties, String redisRef,
-            CredentialDecryptor decryptor) {
-        MiddlewareProperties.RedisEndpoint endpoint = resolveEndpoint(properties, redisRef);
-        String password = decryptor.decrypt(endpoint.getEncryptedPassword(), CredentialSceneType.REDIS_PASSWORD);
-        return buildConnectionMap(endpoint, password);
-    }
-
-    /**
-     * Builds a Redis URL from endpoint settings and password.
-     *
-     * @param endpoint the Redis endpoint
-     * @param password the decrypted password, may be blank
-     * @return the Redis URL string
-     */
-    public static String buildRedisUrl(MiddlewareProperties.RedisEndpoint endpoint, String password) {
-        String host = host(endpoint);
-        int port = port(endpoint);
-        int database = database(endpoint);
-        if (password == null || password.isBlank()) {
-            return "redis://" + host + ":" + port + "/" + database;
-        }
-        String encodedPassword = URLEncoder.encode(password, StandardCharsets.UTF_8);
-        return "redis://:" + encodedPassword + "@" + host + ":" + port + "/" + database;
-    }
-
-    private static void validateClusterNode(String node) {
+    private static NodeAddress parseNode(String node) {
         int colon = node.lastIndexOf(':');
         if (colon <= 0 || colon == node.length() - 1) {
-            throw new IllegalArgumentException("Redis cluster node must use host:port format: " + node);
+            throw new IllegalArgumentException("Invalid Redis node: " + node);
         }
-        try {
-            int port = Integer.parseInt(node.substring(colon + 1));
-            if (port <= 0) {
-                throw new IllegalArgumentException("Redis cluster node port must be positive: " + node);
-            }
-        } catch (NumberFormatException ex) {
-            throw new IllegalArgumentException("Redis cluster node must use host:port format: " + node, ex);
-        }
+        return new NodeAddress(node.substring(0, colon), Integer.parseInt(node.substring(colon + 1)));
     }
 
-    private static String host(MiddlewareProperties.RedisEndpoint endpoint) {
-        String host = endpoint.getHost();
-        if (host == null || host.isBlank()) {
-            return "localhost";
-        }
-        return host.trim();
+    private static String normalizedRef(String redisRef) {
+        return redisRef == null || redisRef.isBlank() ? "default" : redisRef.trim();
     }
 
-    private static int port(MiddlewareProperties.RedisEndpoint endpoint) {
-        return endpoint.getPort() > 0 ? endpoint.getPort() : 6379;
-    }
-
-    private static int database(MiddlewareProperties.RedisEndpoint endpoint) {
-        return endpoint.getDatabase() >= 0 ? endpoint.getDatabase() : 0;
-    }
-
-    private static int timeoutMs(MiddlewareProperties.RedisEndpoint endpoint) {
-        return endpoint.getTimeoutMs() > 0 ? endpoint.getTimeoutMs() : 3000;
+    private record NodeAddress(String host, int port) {
     }
 }

--- a/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisDatasourceDiagnostics.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisDatasourceDiagnostics.java
@@ -43,10 +43,9 @@ public class RedisDatasourceDiagnostics implements SmartInitializingSingleton {
             return;
         }
         String redisRef = properties.getCheckpointer().getRedisRef();
-        MiddlewareProperties.RedisEndpoint endpoint = RedisConnectionAssembler.resolveEndpoint(properties, redisRef);
-        String endpointType = RedisConnectionAssembler.resolveEndpointType(endpoint);
+        ResolvedRedisEndpoint endpoint = RedisConnectionAssembler.resolve(properties, redisRef);
         log.info(diagnosticMessage(properties, redisClient));
-        if (RedisConnectionAssembler.TYPE_CLUSTER.equals(endpointType) && endpoint.getDatabase() != 0) {
+        if (endpoint.isCluster() && endpoint.getDatabase() != 0) {
             log.info("Runtime Redis cluster ignores standalone-only database setting: redis-ref={}, databaseIgnored={}",
                     normalizedRef(redisRef), endpoint.getDatabase());
         }
@@ -54,12 +53,11 @@ public class RedisDatasourceDiagnostics implements SmartInitializingSingleton {
 
     static String diagnosticMessage(MiddlewareProperties properties, RuntimeRedisClient redisClient) {
         String redisRef = properties.getCheckpointer().getRedisRef();
-        MiddlewareProperties.RedisEndpoint endpoint = RedisConnectionAssembler.resolveEndpoint(properties, redisRef);
-        String endpointType = RedisConnectionAssembler.resolveEndpointType(endpoint);
+        ResolvedRedisEndpoint endpoint = RedisConnectionAssembler.resolve(properties, redisRef);
         return "Runtime Redis datasource selected: redis-ref=" + normalizedRef(redisRef) + ", endpoint-type="
-                + endpointType + ", RuntimeRedisClient=" + redisClient.getClass().getSimpleName() + ", ttl-seconds="
-                + properties.getCheckpointer().getTtlSeconds() + ", "
-                + RedisConnectionAssembler.safeSummary(redisRef, endpoint);
+                + endpoint.getType() + ", RuntimeRedisClient=" + redisClient.getClass().getSimpleName()
+                + ", ttl-seconds=" + properties.getCheckpointer().getTtlSeconds() + ", "
+                + RedisConnectionAssembler.safeSummary(endpoint);
     }
 
     private static String normalizedRef(String redisRef) {

--- a/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisJedisClientFactory.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisJedisClientFactory.java
@@ -8,17 +8,18 @@ import com.openjiuwen.service.adapters.common.middleware.MiddlewareProperties;
 
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.DefaultJedisSocketFactory;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.JedisSocketFactory;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 import java.util.LinkedHashSet;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -36,17 +37,30 @@ public final class RedisJedisClientFactory {
      * <p>
      * The returned {@link Jedis} is a single connection and is <b>not
      * thread-safe</b>. Use it only from a single
-     * thread; for concurrent access use {@link #createPooled(MiddlewareProperties.RedisEndpoint, String)}
-     * or {@link #createPool(MiddlewareProperties.RedisEndpoint, String)}.
+     * thread; for concurrent access use {@link #createPooled(ResolvedRedisEndpoint, String)}
+     * or {@link #createPool(ResolvedRedisEndpoint, String)}.
      *
      * @param endpoint redis host/port/database/timeout from properties
      * @param password decrypted password (blank = no auth)
      * @return Jedis
      */
-    public static Jedis createClient(MiddlewareProperties.RedisEndpoint endpoint, String password) {
+    public static Jedis createClient(ResolvedRedisEndpoint endpoint, String password) {
         HostAndPort hostAndPort = hostAndPort(endpoint);
-        return clientConfig(endpoint, password).map(cfg -> new Jedis(hostAndPort, cfg))
-                .orElseGet(() -> new Jedis(hostAndPort));
+        JedisClientConfig config = clientConfig(endpoint, password);
+        Connection connection = new LazyConfiguredConnection(new DefaultJedisSocketFactory(hostAndPort, config),
+                config);
+        return new Jedis(connection);
+    }
+
+    /**
+     * Builds a standalone client after centrally resolving raw endpoint properties.
+     *
+     * @param endpoint raw endpoint properties
+     * @param password decrypted password
+     * @return Jedis
+     */
+    public static Jedis createClient(MiddlewareProperties.RedisEndpoint endpoint, String password) {
+        return createClient(RedisConnectionAssembler.resolveEndpoint("default", endpoint), password);
     }
 
     /**
@@ -60,11 +74,20 @@ public final class RedisJedisClientFactory {
      * @param password decrypted password (blank = no auth)
      * @return a pooled, thread-safe Jedis client
      */
-    public static JedisPooled createPooled(MiddlewareProperties.RedisEndpoint endpoint, String password) {
+    public static JedisPooled createPooled(ResolvedRedisEndpoint endpoint, String password) {
         HostAndPort hostAndPort = hostAndPort(endpoint);
-        JedisClientConfig clientConfig = clientConfig(endpoint, password)
-                .orElseGet(() -> DefaultJedisClientConfig.builder().build());
-        return new JedisPooled(hostAndPort, clientConfig, pooledConnectionConfig());
+        return new JedisPooled(hostAndPort, clientConfig(endpoint, password), pooledConnectionConfig());
+    }
+
+    /**
+     * Builds a pooled standalone client after centrally resolving raw endpoint properties.
+     *
+     * @param endpoint raw endpoint properties
+     * @param password decrypted password
+     * @return a pooled, thread-safe Jedis client
+     */
+    public static JedisPooled createPooled(MiddlewareProperties.RedisEndpoint endpoint, String password) {
+        return createPooled(RedisConnectionAssembler.resolveEndpoint("default", endpoint), password);
     }
 
     /**
@@ -74,15 +97,16 @@ public final class RedisJedisClientFactory {
      * @param password decrypted password (blank = no auth)
      * @return a Jedis cluster client
      */
-    public static JedisCluster createCluster(MiddlewareProperties.RedisEndpoint endpoint, String password) {
+    public static JedisCluster createCluster(ResolvedRedisEndpoint endpoint, String password) {
+        requireType(endpoint, RedisConnectionAssembler.TYPE_CLUSTER);
         Set<HostAndPort> nodes = new LinkedHashSet<>();
-        for (String node : RedisConnectionAssembler.clusterNodes(endpoint)) {
+        for (String node : endpoint.getNodes()) {
             nodes.add(HostAndPort.from(node));
         }
         String previousInitNoError = System.getProperty(JedisCluster.INIT_NO_ERROR_PROPERTY);
         System.setProperty(JedisCluster.INIT_NO_ERROR_PROPERTY, "true");
         try {
-            return new JedisCluster(nodes, clusterClientConfig(endpoint, password), 5, pooledConnectionConfig());
+            return new JedisCluster(nodes, clientConfig(endpoint, password), 5, pooledConnectionConfig());
         } finally {
             if (previousInitNoError == null) {
                 System.clearProperty(JedisCluster.INIT_NO_ERROR_PROPERTY);
@@ -90,6 +114,17 @@ public final class RedisJedisClientFactory {
                 System.setProperty(JedisCluster.INIT_NO_ERROR_PROPERTY, previousInitNoError);
             }
         }
+    }
+
+    /**
+     * Builds a cluster client after centrally resolving raw endpoint properties.
+     *
+     * @param endpoint raw endpoint properties
+     * @param password decrypted password
+     * @return a Jedis cluster client
+     */
+    public static JedisCluster createCluster(MiddlewareProperties.RedisEndpoint endpoint, String password) {
+        return createCluster(RedisConnectionAssembler.resolveEndpoint("default", endpoint), password);
     }
 
     /**
@@ -102,56 +137,52 @@ public final class RedisJedisClientFactory {
      * @param password decrypted password (blank = no auth)
      * @return a pooled, thread-safe Jedis client
      */
-    public static JedisPool createPool(MiddlewareProperties.RedisEndpoint endpoint, String password) {
+    public static JedisPool createPool(ResolvedRedisEndpoint endpoint, String password) {
         HostAndPort hostAndPort = hostAndPort(endpoint);
-        JedisClientConfig clientConfig = clientConfig(endpoint, password)
-                .orElseGet(() -> DefaultJedisClientConfig.builder().build());
-        return new JedisPool(poolConfig(), hostAndPort, clientConfig);
-    }
-
-    private static HostAndPort hostAndPort(MiddlewareProperties.RedisEndpoint endpoint) {
-        String host = endpoint.getHost() != null ? endpoint.getHost().trim() : "localhost";
-        int port = endpoint.getPort() > 0 ? endpoint.getPort() : 6379;
-        return new HostAndPort(host, port);
+        return new JedisPool(poolConfig(), hostAndPort, clientConfig(endpoint, password));
     }
 
     /**
-     * Builds a client config carrying password/database/timeouts, or
-     * {@link Optional#empty()} when neither password
-     * nor a non-zero database is set (preserving the original no-config standalone
-     * behaviour).
+     * Builds a standalone pool after centrally resolving raw endpoint properties.
+     *
+     * @param endpoint raw endpoint properties
+     * @param password decrypted password
+     * @return a pooled, thread-safe Jedis client
+     */
+    public static JedisPool createPool(MiddlewareProperties.RedisEndpoint endpoint, String password) {
+        return createPool(RedisConnectionAssembler.resolveEndpoint("default", endpoint), password);
+    }
+
+    private static HostAndPort hostAndPort(ResolvedRedisEndpoint endpoint) {
+        requireType(endpoint, RedisConnectionAssembler.TYPE_STANDALONE);
+        return new HostAndPort(endpoint.getHost(), endpoint.getPort());
+    }
+
+    /**
+     * Builds a client config that always carries the resolved connection and socket timeouts.
      *
      * @param password password
      * @param endpoint endpoint
-     * @return Optional<JedisClientConfig>
+     * @return Jedis client config
      */
-    private static Optional<JedisClientConfig> clientConfig(MiddlewareProperties.RedisEndpoint endpoint,
-            String password) {
-        int timeoutMs = endpoint.getTimeoutMs() > 0 ? endpoint.getTimeoutMs() : 3000;
+    static JedisClientConfig clientConfig(ResolvedRedisEndpoint endpoint, String password) {
         boolean hasPassword = password != null && !password.isBlank();
-        int database = endpoint.getDatabase();
-        if (!hasPassword && database <= 0) {
-            return Optional.empty();
-        }
-        DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder().connectionTimeoutMillis(timeoutMs)
-                .socketTimeoutMillis(timeoutMs);
+        DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder()
+                .connectionTimeoutMillis(endpoint.getTimeoutMs()).socketTimeoutMillis(endpoint.getTimeoutMs());
         if (hasPassword) {
             builder.password(password);
         }
-        if (database > 0) {
-            builder.database(database);
-        }
-        return Optional.of(builder.build());
-    }
-
-    private static JedisClientConfig clusterClientConfig(MiddlewareProperties.RedisEndpoint endpoint, String password) {
-        int timeoutMs = endpoint.getTimeoutMs() > 0 ? endpoint.getTimeoutMs() : 3000;
-        DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder().connectionTimeoutMillis(timeoutMs)
-                .socketTimeoutMillis(timeoutMs);
-        if (password != null && !password.isBlank()) {
-            builder.password(password);
+        if (!endpoint.isCluster() && endpoint.getDatabase() > 0) {
+            builder.database(endpoint.getDatabase());
         }
         return builder.build();
+    }
+
+    private static void requireType(ResolvedRedisEndpoint endpoint, String requiredType) {
+        if (!requiredType.equals(endpoint.getType())) {
+            throw new IllegalArgumentException("Redis endpoint " + endpoint.getRef() + " has type=" + endpoint.getType()
+                    + ", but this client requires type=" + requiredType);
+        }
     }
 
     private static GenericObjectPoolConfig<Jedis> poolConfig() {
@@ -172,5 +203,31 @@ public final class RedisJedisClientFactory {
         config.setMinIdle(1);
         config.setTestOnBorrow(true);
         config.setTestWhileIdle(true);
+    }
+
+    private static final class LazyConfiguredConnection extends Connection {
+        private boolean isInitialized;
+
+        private LazyConfiguredConnection(JedisSocketFactory socketFactory, JedisClientConfig clientConfig) {
+            super(Connection.builder().socketFactory(socketFactory).clientConfig(clientConfig));
+        }
+
+        @Override
+        public void connect() {
+            if (isInitialized) {
+                super.connect();
+                return;
+            }
+            isInitialized = true;
+            boolean isInitializationSuccessful = false;
+            try {
+                initializeFromClientConfig();
+                isInitializationSuccessful = true;
+            } finally {
+                if (!isInitializationSuccessful) {
+                    isInitialized = false;
+                }
+            }
+        }
     }
 }

--- a/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisMiddlewareAutoConfiguration.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisMiddlewareAutoConfiguration.java
@@ -41,9 +41,9 @@ public class RedisMiddlewareAutoConfiguration {
     @ConditionalOnProperty(prefix = "openjiuwen.service.middleware.checkpointer", name = "type", havingValue = "redis")
     public RuntimeRedisClient runtimeRedisClient(MiddlewareProperties properties, CredentialDecryptor decryptor) {
         String redisRef = properties.getCheckpointer().getRedisRef();
-        MiddlewareProperties.RedisEndpoint endpoint = RedisConnectionAssembler.resolveEndpoint(properties, redisRef);
+        ResolvedRedisEndpoint endpoint = RedisConnectionAssembler.resolve(properties, redisRef);
         String password = decryptor.decrypt(endpoint.getEncryptedPassword(), CredentialSceneType.REDIS_PASSWORD);
-        if (RedisConnectionAssembler.TYPE_CLUSTER.equals(RedisConnectionAssembler.resolveEndpointType(endpoint))) {
+        if (endpoint.isCluster()) {
             return new JedisClusterRuntimeRedisClient(RedisJedisClientFactory.createCluster(endpoint, password));
         }
         return new JedisPooledRuntimeRedisClient(RedisJedisClientFactory.createPooled(endpoint, password));

--- a/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/ResolvedRedisEndpoint.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/main/java/com/openjiuwen/service/adapters/common/middleware/redis/ResolvedRedisEndpoint.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.service.adapters.common.middleware.redis;
+
+import java.util.List;
+
+/**
+ * Immutable, validated Redis endpoint consumed by connection adapters.
+ *
+ * <p>The raw configuration is normalized once by {@link RedisConnectionAssembler}; downstream code must not
+ * reinterpret missing values or introduce connection defaults independently.
+ *
+ * @since 0.1.0
+ */
+public final class ResolvedRedisEndpoint {
+    private final String ref;
+
+    private final String type;
+
+    private final String host;
+
+    private final int port;
+
+    private final List<String> nodes;
+
+    private final int database;
+
+    private final int timeoutMs;
+
+    private final String encryptedPassword;
+
+    ResolvedRedisEndpoint(String ref, String type, String host, int port, List<String> nodes, int database,
+            int timeoutMs, String encryptedPassword) {
+        this.ref = ref;
+        this.type = type;
+        this.host = host;
+        this.port = port;
+        this.nodes = List.copyOf(nodes);
+        this.database = database;
+        this.timeoutMs = timeoutMs;
+        this.encryptedPassword = encryptedPassword;
+    }
+
+    public String getRef() {
+        return ref;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Returns whether this endpoint uses Redis Cluster topology.
+     *
+     * @return {@code true} for a cluster endpoint
+     */
+    public boolean isCluster() {
+        return RedisConnectionAssembler.TYPE_CLUSTER.equals(type);
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public List<String> getNodes() {
+        return nodes;
+    }
+
+    public int getDatabase() {
+        return database;
+    }
+
+    public int getTimeoutMs() {
+        return timeoutMs;
+    }
+
+    public String getEncryptedPassword() {
+        return encryptedPassword;
+    }
+}

--- a/service/agent-service-adapters/agent-service-adapters-common/src/test/java/com/openjiuwen/service/adapters/common/middleware/redis/JedisClusterRuntimeRedisClientTest.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/test/java/com/openjiuwen/service/adapters/common/middleware/redis/JedisClusterRuntimeRedisClientTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.service.adapters.common.middleware.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.util.JedisClusterCRC16;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests topology-aware multi-key commands for Redis Cluster.
+ *
+ * @since 0.1.0
+ */
+class JedisClusterRuntimeRedisClientTest {
+    @Test
+    void mgetGroupsBySlotAndRestoresInputOrderAndMissingValues() {
+        RecordingUnifiedJedis delegate = new RecordingUnifiedJedis();
+        byte[] valueA = bytes("value-a");
+        byte[] valueA2 = bytes("value-a2");
+        delegate.put("{slot-a}:1", valueA);
+        delegate.put("{slot-a}:2", valueA2);
+        JedisClusterRuntimeRedisClient client = new JedisClusterRuntimeRedisClient(delegate);
+
+        List<Object> values = client.mget("{slot-a}:1", "{slot-b}:missing", "{slot-a}:2");
+
+        assertThat(values).containsExactly(valueA, null, valueA2);
+        assertThat(delegate.binaryMgetCalls).hasSize(2);
+        assertEachCallUsesOneSlot(delegate.binaryMgetCalls);
+        assertThat(delegate.binaryMgetCalls.get(0)).hasSize(2);
+    }
+
+    @Test
+    void textDeleteGroupsBySlotAndAccumulatesDeletedCount() {
+        RecordingUnifiedJedis delegate = new RecordingUnifiedJedis();
+        delegate.textKeys.addAll(Set.of("{slot-a}:1", "{slot-a}:2", "{slot-b}:1"));
+        JedisClusterRuntimeRedisClient client = new JedisClusterRuntimeRedisClient(delegate);
+
+        long deleted = client.del("{slot-a}:1", "{slot-b}:1", "{slot-a}:2", "{slot-c}:missing");
+
+        assertThat(deleted).isEqualTo(3);
+        assertThat(delegate.textDelCalls).hasSize(3);
+        assertEachTextCallUsesOneSlot(delegate.textDelCalls);
+    }
+
+    @Test
+    void binaryDeleteUsesRawBytesForSlotAndAccumulatesDeletedCount() {
+        byte[] keyA = new byte[]{0, (byte) 0xff, 1};
+        byte[] keyB = new byte[]{0, (byte) 0xfe, 2};
+        byte[] keyMissing = new byte[]{0, (byte) 0xfd, 3};
+        RecordingUnifiedJedis delegate = new RecordingUnifiedJedis();
+        delegate.binaryKeys.add(fingerprint(keyA));
+        delegate.binaryKeys.add(fingerprint(keyB));
+        JedisClusterRuntimeRedisClient client = new JedisClusterRuntimeRedisClient(delegate);
+
+        long deleted = client.del(keyA, keyMissing, keyB);
+
+        assertThat(deleted).isEqualTo(2);
+        assertEachCallUsesOneSlot(delegate.binaryDelCalls);
+        List<byte[]> delegatedKeys = delegate.binaryDelCalls.stream().flatMap(List::stream).toList();
+        assertThat(delegatedKeys).anySatisfy(key -> assertThat(key).containsExactly(keyA));
+        assertThat(delegatedKeys).anySatisfy(key -> assertThat(key).containsExactly(keyB));
+    }
+
+    @Test
+    void reportsPartialDeleteProgressWithoutExposingKeys() {
+        RecordingUnifiedJedis delegate = new RecordingUnifiedJedis();
+        delegate.textKeys.add("{slot-a}:1");
+        delegate.failTextDeleteSlot = JedisClusterCRC16.getSlot("{slot-b}:1");
+        JedisClusterRuntimeRedisClient client = new JedisClusterRuntimeRedisClient(delegate);
+
+        assertThatThrownBy(() -> client.del("{slot-a}:1", "{slot-b}:1")).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Redis Cluster del failed", "completedGroups=1", "totalGroups=2",
+                        "deletedBeforeFailure=1")
+                .hasMessageNotContaining("{slot-a}").hasMessageNotContaining("{slot-b}")
+                .hasCauseInstanceOf(JedisConnectionException.class);
+    }
+
+    @Test
+    void emptyMultiKeyOperationsDoNotCallRedis() {
+        RecordingUnifiedJedis delegate = new RecordingUnifiedJedis();
+        JedisClusterRuntimeRedisClient client = new JedisClusterRuntimeRedisClient(delegate);
+
+        assertThat(client.mget()).isEmpty();
+        assertThat(client.del(new String[0])).isZero();
+        assertThat(client.del(new byte[0][])).isZero();
+        assertThat(delegate.binaryMgetCalls).isEmpty();
+        assertThat(delegate.textDelCalls).isEmpty();
+        assertThat(delegate.binaryDelCalls).isEmpty();
+    }
+
+    private static void assertEachTextCallUsesOneSlot(List<List<String>> calls) {
+        for (List<String> call : calls) {
+            assertThat(call).extracting(JedisClusterCRC16::getSlot).containsOnly(callSlot(call.get(0)));
+        }
+    }
+
+    private static int callSlot(String key) {
+        return JedisClusterCRC16.getSlot(key);
+    }
+
+    private static void assertEachCallUsesOneSlot(List<List<byte[]>> calls) {
+        for (List<byte[]> call : calls) {
+            assertThat(call).extracting(JedisClusterCRC16::getSlot)
+                    .containsOnly(JedisClusterCRC16.getSlot(call.get(0)));
+        }
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String fingerprint(byte[] value) {
+        return Arrays.toString(value);
+    }
+
+    private static final class RecordingUnifiedJedis extends UnifiedJedis {
+        private final Map<String, byte[]> values = new HashMap<>();
+
+        private final Set<String> textKeys = new HashSet<>();
+
+        private final Set<String> binaryKeys = new HashSet<>();
+
+        private final List<List<byte[]>> binaryMgetCalls = new ArrayList<>();
+
+        private final List<List<String>> textDelCalls = new ArrayList<>();
+
+        private final List<List<byte[]>> binaryDelCalls = new ArrayList<>();
+
+        private int failTextDeleteSlot = -1;
+
+        void put(String key, byte[] value) {
+            values.put(fingerprint(bytes(key)), value);
+        }
+
+        @Override
+        public List<byte[]> mget(byte[]... keys) {
+            binaryMgetCalls.add(copy(keys));
+            return Arrays.stream(keys).map(key -> values.get(fingerprint(key))).toList();
+        }
+
+        @Override
+        public long del(String... keys) {
+            textDelCalls.add(List.of(Arrays.copyOf(keys, keys.length)));
+            if (keys.length > 0 && JedisClusterCRC16.getSlot(keys[0]) == failTextDeleteSlot) {
+                throw new JedisConnectionException("injected failure");
+            }
+            return Arrays.stream(keys).filter(textKeys::remove).count();
+        }
+
+        @Override
+        public long del(byte[]... keys) {
+            binaryDelCalls.add(copy(keys));
+            return Arrays.stream(keys).map(JedisClusterRuntimeRedisClientTest::fingerprint).filter(binaryKeys::remove)
+                    .count();
+        }
+
+        @Override
+        public void close() {
+            // No network resources are created by this recording test double.
+        }
+
+        private static List<byte[]> copy(byte[][] keys) {
+            return Arrays.stream(keys).map(key -> Arrays.copyOf(key, key.length)).toList();
+        }
+    }
+}

--- a/service/agent-service-adapters/agent-service-adapters-common/src/test/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisConnectionAssemblerTest.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/test/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisConnectionAssemblerTest.java
@@ -29,7 +29,7 @@ class RedisConnectionAssemblerTest {
         endpoint.setPort(6380);
         endpoint.setDatabase(2);
 
-        assertThat(RedisConnectionAssembler.buildRedisUrl(endpoint, "plain-pass"))
+        assertThat(RedisConnectionAssembler.buildRedisUrl(resolve("default", endpoint), "plain-pass"))
                 .isEqualTo("redis://:plain-pass@redis.example:6380/2");
     }
 
@@ -41,7 +41,7 @@ class RedisConnectionAssemblerTest {
         endpoint.setEncryptedPassword("ENC");
         properties.getRedis().put("default", endpoint);
 
-        int[] scene = new int[] {CredentialSceneType.UNKNOWN};
+        int[] scene = new int[]{CredentialSceneType.UNKNOWN};
         CredentialDecryptor decryptor = new CredentialDecryptor() {
             @Override
             public String decrypt(String ciphertext) {
@@ -72,9 +72,12 @@ class RedisConnectionAssemblerTest {
     void resolvesBlankEndpointTypeAsStandalone() {
         MiddlewareProperties.RedisEndpoint endpoint = new MiddlewareProperties.RedisEndpoint();
         endpoint.setType(" ");
+        endpoint.setHost(" redis.example ");
 
-        assertThat(RedisConnectionAssembler.resolveEndpointType(endpoint))
-                .isEqualTo(RedisConnectionAssembler.TYPE_STANDALONE);
+        ResolvedRedisEndpoint resolved = resolve("default", endpoint);
+
+        assertThat(resolved.getType()).isEqualTo(RedisConnectionAssembler.TYPE_STANDALONE);
+        assertThat(resolved.getHost()).isEqualTo("redis.example");
     }
 
     @Test
@@ -82,8 +85,7 @@ class RedisConnectionAssemblerTest {
         MiddlewareProperties.RedisEndpoint endpoint = new MiddlewareProperties.RedisEndpoint();
         endpoint.setType("sentinel");
 
-        assertThatThrownBy(() -> RedisConnectionAssembler.resolveEndpointType(endpoint))
-                .isInstanceOf(IllegalArgumentException.class)
+        assertThatThrownBy(() -> resolve("default", endpoint)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported openjiuwen.service.middleware.redis endpoint type: sentinel");
     }
 
@@ -94,8 +96,10 @@ class RedisConnectionAssemblerTest {
         endpoint.setNodes(List.of("10.10.1.11:6379", "10.10.1.12:6379"));
         endpoint.setDatabase(2);
 
-        assertThat(RedisConnectionAssembler.clusterNodes(endpoint)).containsExactly("10.10.1.11:6379",
-                "10.10.1.12:6379");
+        ResolvedRedisEndpoint resolved = resolve("cluster", endpoint);
+
+        assertThat(resolved.getNodes()).containsExactly("10.10.1.11:6379", "10.10.1.12:6379");
+        assertThat(resolved.getDatabase()).isEqualTo(2);
     }
 
     @Test
@@ -103,8 +107,8 @@ class RedisConnectionAssemblerTest {
         MiddlewareProperties.RedisEndpoint endpoint = new MiddlewareProperties.RedisEndpoint();
         endpoint.setType("cluster");
 
-        assertThatThrownBy(() -> RedisConnectionAssembler.clusterNodes(endpoint))
-                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("nodes");
+        assertThatThrownBy(() -> resolve("cluster", endpoint)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("redis.cluster.nodes");
     }
 
     @Test
@@ -113,8 +117,51 @@ class RedisConnectionAssemblerTest {
         endpoint.setType("cluster");
         endpoint.setNodes(List.of("10.10.1.11"));
 
-        assertThatThrownBy(() -> RedisConnectionAssembler.clusterNodes(endpoint))
-                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("host:port");
+        assertThatThrownBy(() -> resolve("cluster", endpoint)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("host:port");
+    }
+
+    @Test
+    void requiresStandaloneHostWithoutLocalhostFallback() {
+        for (String host : new String[]{null, "", "   "}) {
+            MiddlewareProperties.RedisEndpoint endpoint = new MiddlewareProperties.RedisEndpoint();
+            endpoint.setHost(host);
+
+            assertThatThrownBy(() -> resolve("primary", endpoint)).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("openjiuwen.service.middleware.redis.primary.host is required when type=standalone");
+        }
+    }
+
+    @Test
+    void validatesBeforeDecryptingCredentials() {
+        MiddlewareProperties properties = new MiddlewareProperties();
+        MiddlewareProperties.RedisEndpoint endpoint = new MiddlewareProperties.RedisEndpoint();
+        endpoint.setEncryptedPassword("ENC(secret)");
+        properties.getRedis().put("default", endpoint);
+        int[] decryptCalls = new int[1];
+        CredentialDecryptor decryptor = ciphertext -> {
+            decryptCalls[0]++;
+            return "secret";
+        };
+
+        assertThatThrownBy(() -> RedisConnectionAssembler.buildConnectionMap(properties, "default", decryptor))
+                .hasMessageContaining("redis.default.host");
+        assertThat(decryptCalls[0]).isZero();
+    }
+
+    @Test
+    void appliesConnectionDefaultsOnlyDuringResolution() {
+        MiddlewareProperties.RedisEndpoint endpoint = new MiddlewareProperties.RedisEndpoint();
+        endpoint.setHost("redis.example");
+        endpoint.setPort(0);
+        endpoint.setDatabase(-1);
+        endpoint.setTimeoutMs(0);
+
+        ResolvedRedisEndpoint resolved = resolve("default", endpoint);
+
+        assertThat(resolved.getPort()).isEqualTo(6379);
+        assertThat(resolved.getDatabase()).isZero();
+        assertThat(resolved.getTimeoutMs()).isEqualTo(3000);
     }
 
     @Test
@@ -126,7 +173,7 @@ class RedisConnectionAssemblerTest {
         standalone.setTimeoutMs(1500);
         standalone.setEncryptedPassword("ENC(secret)");
 
-        assertThat(RedisConnectionAssembler.safeSummary("default", standalone))
+        assertThat(RedisConnectionAssembler.safeSummary(resolve("default", standalone)))
                 .contains("ref=default", "type=standalone", "host=redis.example", "port=6380", "database=2",
                         "timeoutMs=1500", "passwordConfigured=true")
                 .doesNotContain("ENC(secret)");
@@ -137,8 +184,23 @@ class RedisConnectionAssemblerTest {
         cluster.setDatabase(2);
         cluster.setEncryptedPassword("ENC(cluster-secret)");
 
-        assertThat(RedisConnectionAssembler.safeSummary("cluster", cluster))
+        assertThat(RedisConnectionAssembler.safeSummary(resolve("cluster", cluster)))
                 .contains("ref=cluster", "type=cluster", "nodes=2", "databaseIgnored=2", "passwordConfigured=true")
                 .doesNotContain("ENC(cluster-secret)");
+    }
+
+    @Test
+    void usesFirstClusterNodeAsAgentCoreConnectionSeed() {
+        MiddlewareProperties.RedisEndpoint cluster = new MiddlewareProperties.RedisEndpoint();
+        cluster.setType("cluster");
+        cluster.setNodes(List.of("10.10.1.11:6380", "10.10.1.12:6381"));
+        cluster.setDatabase(2);
+
+        assertThat(RedisConnectionAssembler.buildRedisUrl(resolve("cluster", cluster), ""))
+                .isEqualTo("redis://10.10.1.11:6380/0");
+    }
+
+    private static ResolvedRedisEndpoint resolve(String ref, MiddlewareProperties.RedisEndpoint endpoint) {
+        return RedisConnectionAssembler.resolveEndpoint(ref, endpoint);
     }
 }

--- a/service/agent-service-adapters/agent-service-adapters-common/src/test/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisJedisClientFactoryTest.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/test/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisJedisClientFactoryTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.openjiuwen.service.adapters.common.middleware.MiddlewareProperties;
 
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisPooled;
 
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ class RedisJedisClientFactoryTest {
         endpoint.setDatabase(0);
         endpoint.setTimeoutMs(5000);
 
-        Jedis jedis = RedisJedisClientFactory.createClient(endpoint, "");
+        Jedis jedis = RedisJedisClientFactory.createClient(resolve(endpoint), "");
         assertThat(jedis).isNotNull();
         assertThat(jedis.isConnected()).isFalse();
         jedis.close();
@@ -41,8 +42,42 @@ class RedisJedisClientFactoryTest {
         endpoint.setDatabase(0);
         endpoint.setTimeoutMs(5000);
 
-        try (JedisPooled jedis = RedisJedisClientFactory.createPooled(endpoint, "")) {
+        try (JedisPooled jedis = RedisJedisClientFactory.createPooled(resolve(endpoint), "")) {
             assertThat(jedis).isNotNull();
         }
+    }
+
+    @Test
+    void appliesTimeoutWithoutAuthenticationOrNonDefaultDatabase() {
+        MiddlewareProperties.RedisEndpoint endpoint = new MiddlewareProperties.RedisEndpoint();
+        endpoint.setHost("127.0.0.1");
+        endpoint.setDatabase(0);
+        endpoint.setTimeoutMs(1234);
+
+        JedisClientConfig config = RedisJedisClientFactory.clientConfig(resolve(endpoint), "");
+
+        assertThat(config.getConnectionTimeoutMillis()).isEqualTo(1234);
+        assertThat(config.getSocketTimeoutMillis()).isEqualTo(1234);
+        assertThat(config.getDatabase()).isZero();
+        assertThat(config.getPassword()).isNull();
+    }
+
+    @Test
+    void appliesSameTimeoutWithPasswordAndDatabase() {
+        MiddlewareProperties.RedisEndpoint endpoint = new MiddlewareProperties.RedisEndpoint();
+        endpoint.setHost("127.0.0.1");
+        endpoint.setDatabase(2);
+        endpoint.setTimeoutMs(2345);
+
+        JedisClientConfig config = RedisJedisClientFactory.clientConfig(resolve(endpoint), "secret");
+
+        assertThat(config.getConnectionTimeoutMillis()).isEqualTo(2345);
+        assertThat(config.getSocketTimeoutMillis()).isEqualTo(2345);
+        assertThat(config.getDatabase()).isEqualTo(2);
+        assertThat(config.getPassword()).isEqualTo("secret");
+    }
+
+    private static ResolvedRedisEndpoint resolve(MiddlewareProperties.RedisEndpoint endpoint) {
+        return RedisConnectionAssembler.resolveEndpoint("default", endpoint);
     }
 }

--- a/service/agent-service-adapters/agent-service-adapters-common/src/test/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisMiddlewareAutoConfigurationTest.java
+++ b/service/agent-service-adapters/agent-service-adapters-common/src/test/java/com/openjiuwen/service/adapters/common/middleware/redis/RedisMiddlewareAutoConfigurationTest.java
@@ -113,6 +113,29 @@ class RedisMiddlewareAutoConfigurationTest {
     }
 
     @Test
+    void failsFastWhenStandaloneHostIsMissing() {
+        AtomicInteger decryptCalls = new AtomicInteger();
+        contextRunner.withBean(CredentialDecryptor.class, () -> countingDecryptor(decryptCalls))
+                .withPropertyValues("openjiuwen.service.middleware.checkpointer.type=redis",
+                        "openjiuwen.service.middleware.redis.default.type=standalone",
+                        "openjiuwen.service.middleware.redis.default.encrypted-password=ENC(secret)")
+                .run(context -> {
+                    assertThat(context.getStartupFailure()).hasRootCauseMessage(
+                            "openjiuwen.service.middleware.redis.default.host is required when type=standalone");
+                    assertThat(decryptCalls).hasValue(0);
+                });
+    }
+
+    @Test
+    void failsFastWhenStandaloneHostIsBlank() {
+        contextRunner
+                .withPropertyValues("openjiuwen.service.middleware.checkpointer.type=redis",
+                        "openjiuwen.service.middleware.redis.default.host=   ")
+                .run(context -> assertThat(context.getStartupFailure()).hasRootCauseMessage(
+                        "openjiuwen.service.middleware.redis.default.host is required when type=standalone"));
+    }
+
+    @Test
     void failsFastWhenCheckpointerTtlIsNotPositive() {
         contextRunner
                 .withPropertyValues("openjiuwen.service.middleware.checkpointer.type=redis",
@@ -162,6 +185,22 @@ class RedisMiddlewareAutoConfigurationTest {
             @Override
             public String decrypt(String ciphertext, int sceneType) {
                 scene.set(sceneType);
+                return "redis-password";
+            }
+        };
+    }
+
+    private static CredentialDecryptor countingDecryptor(AtomicInteger calls) {
+        return new CredentialDecryptor() {
+            @Override
+            public String decrypt(String ciphertext) {
+                calls.incrementAndGet();
+                return "redis-password";
+            }
+
+            @Override
+            public String decrypt(String ciphertext, int sceneType) {
+                calls.incrementAndGet();
                 return "redis-password";
             }
         };


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

/kind bug

## What changed

- Introduce an immutable `ResolvedRedisEndpoint` and centralize endpoint normalization and validation before credential decryption, client construction, and diagnostics.
- Remove every implicit standalone `localhost` fallback; a missing or blank host now fails fast with the exact configuration path.
- Always build and apply one `JedisClientConfig`, so connection/socket timeout is honored for every password/database combination while preserving lazy connection behavior.
- Make Redis Cluster `mget` and both multi-key `del` variants topology-transparent by grouping keys by hash slot, restoring original `mget` ordering and null placeholders, and reporting non-sensitive partial-progress context on failures.
- Use a validated cluster seed node when producing the agent-core connection map instead of a hidden localhost fallback.

## Root cause

Redis endpoint defaults and normalization were duplicated across the property model, connection assembler, and Jedis factory. This allowed invalid standalone configuration and caused effective client settings to diverge from diagnostics. Separately, the cluster adapter inherited multi-key commands that require all keys to share one slot.

## Verification

- Targeted Redis regression tests: 32 passed.
- Affected reactor: spec 12 passed; adapters-common 47 passed; adapters-agentcore 116 run with 0 failures/errors and 4 environment-dependent skips.
- Real standalone Redis Testcontainers integration flows passed.
- Real three-master Redis Cluster smoke passed cross-node ordered `MGET` (including missing/null), text `DEL`, and binary `DEL`.
- Real LLM + Redis A2A smoke passed Agent A/B/C health, Agent Cards, A -> B confirmation/resume, and A -> B -> C confirmation/resume.
- `git diff --check`, Eclipse JDT formatting, and Checkstyle passed.

## Self-check

- [x] Design follows existing adapter boundaries and centralizes endpoint invariants.
- [x] Regression and affected-module tests pass.
- [x] Real Redis and end-to-end A2A verification pass.
- [x] Public raw-property overloads remain as compatibility adapters.
- [x] No documentation change is required; configuration behavior now matches the documented required endpoint.

Fixes #45
Fixes #47
Fixes #50