### PR TITLE
fix(a2a): honor Spring configuration for sync timeout

### DIFF
--- a/service/agent-service-app/src/main/java/com/openjiuwen/service/app/autoconfigure/A2AAutoConfiguration.java
+++ b/service/agent-service-app/src/main/java/com/openjiuwen/service/app/autoconfigure/A2AAutoConfiguration.java
@@ -45,6 +45,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 
+import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +60,8 @@ import java.util.concurrent.TimeUnit;
 @ConditionalOnClass(AgentExecutor.class)
 @EnableConfigurationProperties(A2AProperties.class)
 public class A2AAutoConfiguration {
+    private static final Map<String, String> A2A_RUNTIME_DEFAULTS = Map.of("a2a.blocking.agent.timeout.seconds", "300");
+
     /**
      * Creates the SDK main event bus bean.
      *
@@ -163,7 +166,7 @@ public class A2AAutoConfiguration {
     @ConditionalOnMissingBean
     public A2AConfigProvider a2aConfigProvider(Environment environment, AutowireCapableBeanFactory beanFactory) {
         DefaultValuesConfigProvider defaults = beanFactory.createBean(DefaultValuesConfigProvider.class);
-        return new SpringEnvironmentConfigProvider(environment, defaults);
+        return new SpringEnvironmentConfigProvider(environment, defaults, A2A_RUNTIME_DEFAULTS);
     }
 
     /**

--- a/service/agent-service-app/src/main/java/com/openjiuwen/service/app/autoconfigure/A2AAutoConfiguration.java
+++ b/service/agent-service-app/src/main/java/com/openjiuwen/service/app/autoconfigure/A2AAutoConfiguration.java
@@ -7,6 +7,7 @@ package com.openjiuwen.service.app.autoconfigure;
 import com.openjiuwen.service.adapters.common.middleware.MiddlewareProperties;
 import com.openjiuwen.service.adapters.common.middleware.redis.RedisMiddlewareAutoConfiguration;
 import com.openjiuwen.service.app.config.A2AProperties;
+import com.openjiuwen.service.app.config.SpringEnvironmentConfigProvider;
 import com.openjiuwen.service.app.controller.a2a.A2AAgentExecutor;
 import com.openjiuwen.service.app.controller.a2a.A2AProtocolAdapter;
 import com.openjiuwen.service.app.controller.a2a.RedisTaskStore;
@@ -36,11 +37,13 @@ import org.a2aproject.sdk.server.tasks.PushNotificationSender;
 import org.a2aproject.sdk.server.tasks.TaskStore;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
 
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -150,14 +153,17 @@ public class A2AAutoConfiguration {
     }
 
     /**
-     * Creates the A2A config provider bean with SDK defaults.
+     * Creates the A2A config provider bean backed by the Spring environment and SDK defaults.
      *
+     * @param environment the Spring environment
+     * @param beanFactory the bean factory used to initialize the SDK defaults provider
      * @return the A2A config provider
      */
     @Bean
     @ConditionalOnMissingBean
-    public A2AConfigProvider a2aConfigProvider() {
-        return new DefaultValuesConfigProvider();
+    public A2AConfigProvider a2aConfigProvider(Environment environment, AutowireCapableBeanFactory beanFactory) {
+        DefaultValuesConfigProvider defaults = beanFactory.createBean(DefaultValuesConfigProvider.class);
+        return new SpringEnvironmentConfigProvider(environment, defaults);
     }
 
     /**

--- a/service/agent-service-app/src/main/java/com/openjiuwen/service/app/config/SpringEnvironmentConfigProvider.java
+++ b/service/agent-service-app/src/main/java/com/openjiuwen/service/app/config/SpringEnvironmentConfigProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.service.app.config;
+
+import org.a2aproject.sdk.server.config.A2AConfigProvider;
+import org.springframework.core.env.Environment;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Resolves A2A SDK configuration from the Spring environment before falling back to SDK defaults.
+ *
+ * @since 0.1.0
+ */
+public class SpringEnvironmentConfigProvider implements A2AConfigProvider {
+    private final Environment environment;
+
+    private final A2AConfigProvider defaults;
+
+    /**
+     * Creates a Spring environment backed A2A configuration provider.
+     *
+     * @param environment the Spring environment
+     * @param defaults the initialized SDK defaults provider
+     */
+    public SpringEnvironmentConfigProvider(Environment environment, A2AConfigProvider defaults) {
+        this.environment = Objects.requireNonNull(environment, "environment must not be null");
+        this.defaults = Objects.requireNonNull(defaults, "defaults must not be null");
+    }
+
+    @Override
+    public String getValue(String name) {
+        String value = environment.getProperty(name);
+        return value != null ? value : defaults.getValue(name);
+    }
+
+    @Override
+    public Optional<String> getOptionalValue(String name) {
+        return Optional.ofNullable(environment.getProperty(name)).or(() -> defaults.getOptionalValue(name));
+    }
+}

--- a/service/agent-service-app/src/main/java/com/openjiuwen/service/app/config/SpringEnvironmentConfigProvider.java
+++ b/service/agent-service-app/src/main/java/com/openjiuwen/service/app/config/SpringEnvironmentConfigProvider.java
@@ -7,6 +7,7 @@ package com.openjiuwen.service.app.config;
 import org.a2aproject.sdk.server.config.A2AConfigProvider;
 import org.springframework.core.env.Environment;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -20,6 +21,8 @@ public class SpringEnvironmentConfigProvider implements A2AConfigProvider {
 
     private final A2AConfigProvider defaults;
 
+    private final Map<String, String> runtimeDefaults;
+
     /**
      * Creates a Spring environment backed A2A configuration provider.
      *
@@ -27,18 +30,36 @@ public class SpringEnvironmentConfigProvider implements A2AConfigProvider {
      * @param defaults the initialized SDK defaults provider
      */
     public SpringEnvironmentConfigProvider(Environment environment, A2AConfigProvider defaults) {
+        this(environment, defaults, Map.of());
+    }
+
+    /**
+     * Creates a Spring environment backed A2A configuration provider with Runtime defaults.
+     *
+     * @param environment the Spring environment
+     * @param defaults the initialized SDK defaults provider
+     * @param runtimeDefaults defaults selected by Agent Runtime
+     */
+    public SpringEnvironmentConfigProvider(Environment environment, A2AConfigProvider defaults,
+            Map<String, String> runtimeDefaults) {
         this.environment = Objects.requireNonNull(environment, "environment must not be null");
         this.defaults = Objects.requireNonNull(defaults, "defaults must not be null");
+        this.runtimeDefaults = Map.copyOf(Objects.requireNonNull(runtimeDefaults, "runtimeDefaults must not be null"));
     }
 
     @Override
     public String getValue(String name) {
         String value = environment.getProperty(name);
+        if (value != null) {
+            return value;
+        }
+        value = runtimeDefaults.get(name);
         return value != null ? value : defaults.getValue(name);
     }
 
     @Override
     public Optional<String> getOptionalValue(String name) {
-        return Optional.ofNullable(environment.getProperty(name)).or(() -> defaults.getOptionalValue(name));
+        return Optional.ofNullable(environment.getProperty(name))
+                .or(() -> Optional.ofNullable(runtimeDefaults.get(name))).or(() -> defaults.getOptionalValue(name));
     }
 }

--- a/service/agent-service-app/src/test/java/com/openjiuwen/service/app/autoconfigure/A2AAutoConfigurationTest.java
+++ b/service/agent-service-app/src/test/java/com/openjiuwen/service/app/autoconfigure/A2AAutoConfigurationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.service.app.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.openjiuwen.service.app.config.SpringEnvironmentConfigProvider;
+import com.openjiuwen.service.spec.spi.ServeOrchestrator;
+
+import org.a2aproject.sdk.server.config.A2AConfigProvider;
+import org.a2aproject.sdk.server.requesthandlers.RequestHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Auto-configuration tests for A2A SDK configuration.
+ */
+class A2AAutoConfigurationTest {
+    private static final String AGENT_TIMEOUT = "a2a.blocking.agent.timeout.seconds";
+
+    private static final String CONSUMPTION_TIMEOUT = "a2a.blocking.consumption.timeout.seconds";
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(A2AAutoConfiguration.class))
+            .withBean(ServeOrchestrator.class, () -> mock(ServeOrchestrator.class))
+            .withBean(RequestHandler.class, () -> mock(RequestHandler.class));
+
+    @Test
+    void a2aConfigProviderUsesSpringApplicationProperty() {
+        contextRunner.withPropertyValues(AGENT_TIMEOUT + "=120").run(context -> {
+            A2AConfigProvider provider = context.getBean(A2AConfigProvider.class);
+
+            assertThat(provider).isInstanceOf(SpringEnvironmentConfigProvider.class);
+            assertThat(provider.getValue(AGENT_TIMEOUT)).isEqualTo("120");
+            assertThat(provider.getOptionalValue(AGENT_TIMEOUT)).contains("120");
+        });
+    }
+
+    @Test
+    void a2aConfigProviderUsesSystemProperty() {
+        contextRunner.withSystemProperties(AGENT_TIMEOUT + "=90").run(context -> {
+            A2AConfigProvider provider = context.getBean(A2AConfigProvider.class);
+
+            assertThat(provider.getValue(AGENT_TIMEOUT)).isEqualTo("90");
+        });
+    }
+
+    @Test
+    void a2aConfigProviderFallsBackToInitializedSdkDefaults() {
+        contextRunner.run(context -> {
+            A2AConfigProvider provider = context.getBean(A2AConfigProvider.class);
+
+            assertThat(provider.getValue(AGENT_TIMEOUT)).isEqualTo("30");
+            assertThat(provider.getOptionalValue(CONSUMPTION_TIMEOUT)).contains("5");
+        });
+    }
+
+    @Test
+    void a2aConfigProviderAllowsCustomProviderOverride() {
+        A2AConfigProvider customProvider = mock(A2AConfigProvider.class);
+
+        contextRunner.withBean(A2AConfigProvider.class, () -> customProvider).run(context -> {
+            assertThat(context).hasSingleBean(A2AConfigProvider.class);
+            assertThat(context.getBean(A2AConfigProvider.class)).isSameAs(customProvider);
+        });
+    }
+}

--- a/service/agent-service-app/src/test/java/com/openjiuwen/service/app/autoconfigure/A2AAutoConfigurationTest.java
+++ b/service/agent-service-app/src/test/java/com/openjiuwen/service/app/autoconfigure/A2AAutoConfigurationTest.java
@@ -50,11 +50,11 @@ class A2AAutoConfigurationTest {
     }
 
     @Test
-    void a2aConfigProviderFallsBackToInitializedSdkDefaults() {
+    void a2aConfigProviderUsesRuntimeDefaultAndInitializedSdkFallback() {
         contextRunner.run(context -> {
             A2AConfigProvider provider = context.getBean(A2AConfigProvider.class);
 
-            assertThat(provider.getValue(AGENT_TIMEOUT)).isEqualTo("30");
+            assertThat(provider.getValue(AGENT_TIMEOUT)).isEqualTo("300");
             assertThat(provider.getOptionalValue(CONSUMPTION_TIMEOUT)).contains("5");
         });
     }


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

/kind bug

## Summary

`A2A_SYNC` now honors Spring Boot configuration for the SDK blocking timeout. The A2A config provider resolves values in this order:

1. Spring `Environment`, including `application.yml`, system properties, and environment variables
2. Agent Runtime defaults
3. A2A SDK classpath defaults

Agent Runtime presets `a2a.blocking.agent.timeout.seconds` to **300 seconds** so an unconfigured multi-agent transaction is not constrained by the SDK's LLM-unfriendly 30-second default. Applications can still explicitly raise or lower it. Other settings, including the 5-second consumption timeout, continue to use SDK defaults.

The SDK `DefaultValuesConfigProvider` is created through Spring's bean factory so its `@PostConstruct` initialization still loads `META-INF/a2a-defaults.properties`.

## Root Cause

`A2AAutoConfiguration` registered `DefaultValuesConfigProvider` directly. That provider only reads classpath defaults and does not read Spring configuration sources, so `a2a.blocking.agent.timeout.seconds` remained fixed at 30 seconds. That value is too short for nested LLM/A2A transactions and can return a non-terminal WORKING snapshot just before the actual COMPLETED event.

## Verification

- Targeted: `A2AAutoConfigurationTest` (4 tests passed), covering explicit Spring/system overrides, Runtime default 300, SDK fallback 5, and custom provider override
- Affected modules: spec 12, adapters-common 46, app 200 tests passed
- `git diff --check` passed
- Pre-commit Eclipse JDT and Checkstyle passed
- Real LLM + Redis A2A smoke passed without explicitly configuring the A2A blocking timeout: Agent A/B/C health, Agent Cards, A -> B confirmation/resume, and A -> B -> C confirmation/resume
- Fork push Git Hooks passed

Fixes #36
Fixes #51

## Checklist

- [x] Design reviewed and root cause addressed
- [x] Regression tests added
- [x] Unit/module verification completed
- [x] Real A2A end-to-end smoke completed
- [x] Documentation reviewed; configuration precedence and default are documented here